### PR TITLE
Improve Pushfight UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,54 +1,95 @@
 <html>
     <head>
         <title>Pushfight</title>
+        <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap" rel="stylesheet">
         <style>
             body {
-                background: cyan;
+                margin: 0;
+                background: #f5f5f5;
+                font-family: 'Roboto', sans-serif;
+                display: flex;
+                flex-direction: column;
+                align-items: center;
+            }
+
+            #board {
+                margin-top: 20px;
+                background: #fafafa;
+                box-shadow: 0 2px 8px rgba(0,0,0,0.2);
+                border-radius: 4px;
+            }
+
+            #container {
+                display: flex;
+                justify-content: center;
+            }
+
+            .tile {
+                fill: #e0e0e0;
+                stroke: #444;
+            }
+
+            .piece.square {
+                rx: 8;
+                ry: 8;
+            }
+
+            #log {
+                margin-left: 20px;
+                max-height: 450px;
+                overflow-y: auto;
+                font-size: 14px;
+            }
+
+            #player, #turn {
+                font-size: 18px;
+                margin: 10px 0;
+                font-weight: bold;
             }
         </style>
     </head>
     <body>
 
-        <div>
-        <svg style="float:left" id="board" version="1.1"
+        <div id="container">
+        <svg id="board" version="1.1"
             baseProfile="full"
             width="250" height="450"
             xmlns="http://www.w3.org/2000/svg">
 
-        <rect class="tile B1" x="50" y="0" width="50" height="50" stroke="black" fill="transparent" stroke-width="1"/>
-        <rect class="tile C1" x="100" y="0" width="50" height="50" stroke="black" fill="transparent" stroke-width="1"/>
+        <rect class="tile B1" x="50" y="0" width="50" height="50" stroke="black" stroke-width="1"/>
+        <rect class="tile C1" x="100" y="0" width="50" height="50" stroke="black" stroke-width="1"/>
 
-        <rect class="tile A2" x="0" y="50" width="50" height="50" stroke="black" fill="transparent" stroke-width="1"/>
-        <rect class="tile B2" x="50" y="50" width="50" height="50" stroke="black" fill="transparent" stroke-width="1"/>
-        <rect class="tile C2" x="100" y="50" width="50" height="50" stroke="black" fill="transparent" stroke-width="1"/>
+        <rect class="tile A2" x="0" y="50" width="50" height="50" stroke="black" stroke-width="1"/>
+        <rect class="tile B2" x="50" y="50" width="50" height="50" stroke="black" stroke-width="1"/>
+        <rect class="tile C2" x="100" y="50" width="50" height="50" stroke="black" stroke-width="1"/>
        
-        <rect class="tile A3" x="0" y="100" width="50" height="50" stroke="black" fill="transparent" stroke-width="1"/>
-        <rect class="tile B3" x="50" y="100" width="50" height="50" stroke="black" fill="transparent" stroke-width="1"/>
-        <rect class="tile C3" x="100" y="100" width="50" height="50" stroke="black" fill="transparent" stroke-width="1"/>
-        <rect class="tile D3" x="150" y="100" width="50" height="50" stroke="black" fill="transparent" stroke-width="1"/>
+        <rect class="tile A3" x="0" y="100" width="50" height="50" stroke="black" stroke-width="1"/>
+        <rect class="tile B3" x="50" y="100" width="50" height="50" stroke="black" stroke-width="1"/>
+        <rect class="tile C3" x="100" y="100" width="50" height="50" stroke="black" stroke-width="1"/>
+        <rect class="tile D3" x="150" y="100" width="50" height="50" stroke="black" stroke-width="1"/>
 
-        <rect class="tile A4" x="0" y="150" width="50" height="50" stroke="black" fill="transparent" stroke-width="1"/>
-        <rect class="tile B4" x="50" y="150" width="50" height="50" stroke="black" fill="transparent" stroke-width="1"/>
-        <rect class="tile C4" x="100" y="150" width="50" height="50" stroke="black" fill="transparent" stroke-width="1"/>
-        <rect class="tile D4" x="150" y="150" width="50" height="50" stroke="black" fill="transparent" stroke-width="1"/>
+        <rect class="tile A4" x="0" y="150" width="50" height="50" stroke="black" stroke-width="1"/>
+        <rect class="tile B4" x="50" y="150" width="50" height="50" stroke="black" stroke-width="1"/>
+        <rect class="tile C4" x="100" y="150" width="50" height="50" stroke="black" stroke-width="1"/>
+        <rect class="tile D4" x="150" y="150" width="50" height="50" stroke="black" stroke-width="1"/>
 
-        <rect class="tile A5" x="0" y="200" width="50" height="50" stroke="black" fill="transparent" stroke-width="1"/>
-        <rect class="tile B5" x="50" y="200" width="50" height="50" stroke="black" fill="transparent" stroke-width="1"/>
-        <rect class="tile C5" x="100" y="200" width="50" height="50" stroke="black" fill="transparent" stroke-width="1"/>
-        <rect class="tile D5" x="150" y="200" width="50" height="50" stroke="black" fill="transparent" stroke-width="1"/>
+        <rect class="tile A5" x="0" y="200" width="50" height="50" stroke="black" stroke-width="1"/>
+        <rect class="tile B5" x="50" y="200" width="50" height="50" stroke="black" stroke-width="1"/>
+        <rect class="tile C5" x="100" y="200" width="50" height="50" stroke="black" stroke-width="1"/>
+        <rect class="tile D5" x="150" y="200" width="50" height="50" stroke="black" stroke-width="1"/>
 
-        <rect class="tile A6" x="0" y="250" width="50" height="50" stroke="black" fill="transparent" stroke-width="1"/>
-        <rect class="tile B6" x="50" y="250" width="50" height="50" stroke="black" fill="transparent" stroke-width="1"/>
-        <rect class="tile C6" x="100" y="250" width="50" height="50" stroke="black" fill="transparent" stroke-width="1"/>
-        <rect class="tile D6" x="150" y="250" width="50" height="50" stroke="black" fill="transparent" stroke-width="1"/>
+        <rect class="tile A6" x="0" y="250" width="50" height="50" stroke="black" stroke-width="1"/>
+        <rect class="tile B6" x="50" y="250" width="50" height="50" stroke="black" stroke-width="1"/>
+        <rect class="tile C6" x="100" y="250" width="50" height="50" stroke="black" stroke-width="1"/>
+        <rect class="tile D6" x="150" y="250" width="50" height="50" stroke="black" stroke-width="1"/>
         
         
-        <rect class="tile B7" x="50" y="300" width="50" height="50" stroke="black" fill="transparent" stroke-width="1"/>
-        <rect class="tile C7" x="100" y="300" width="50" height="50" stroke="black" fill="transparent" stroke-width="1"/>
-        <rect class="tile D7" x="150" y="300" width="50" height="50" stroke="black" fill="transparent" stroke-width="1"/>
+        <rect class="tile B7" x="50" y="300" width="50" height="50" stroke="black" stroke-width="1"/>
+        <rect class="tile C7" x="100" y="300" width="50" height="50" stroke="black" stroke-width="1"/>
+        <rect class="tile D7" x="150" y="300" width="50" height="50" stroke="black" stroke-width="1"/>
 
-        <rect class="tile B8" x="50" y="350" width="50" height="50" stroke="black" fill="transparent" stroke-width="1"/>
-        <rect class="tile C8" x="100" y="350" width="50" height="50" stroke="black" fill="transparent" stroke-width="1"/>
+        <rect class="tile B8" x="50" y="350" width="50" height="50" stroke="black" stroke-width="1"/>
+        <rect class="tile C8" x="100" y="350" width="50" height="50" stroke="black" stroke-width="1"/>
 
         <text x="225" y="25" font-size="16" text-anchor="middle" fill="black">1</text>
         <text x="225" y="75" font-size="16" text-anchor="middle" fill="black">2</text>
@@ -81,10 +122,10 @@
         </text>
         </svg>
 
-        <div id="log" style="float:left"></div>
+        <div id="log"></div>
         </div>
 
-        <p style="clear:both" id="player"></p>
+        <p id="player"></p>
         <p id="turn"></p>
         <script type="text/javascript">
             let turn = 0;


### PR DESCRIPTION
## Summary
- restyle the game board with a cleaner look
- use a flexbox layout and remove inline styling
- add Roboto font and centralize player/turn display

## Testing
- `go test ./...` *(fails: no go.mod)*

------
https://chatgpt.com/codex/tasks/task_e_6840ee91c8308326945adab15a9ee95d